### PR TITLE
Enhance user display name retrieval in _LoginPartial

### DIFF
--- a/src/Aspire/Aspire.AspNet.Mvc/Views/Shared/_LoginPartial.cshtml
+++ b/src/Aspire/Aspire.AspNet.Mvc/Views/Shared/_LoginPartial.cshtml
@@ -1,9 +1,11 @@
 ﻿@using System.Security.Principal
+@using System.Security.Claims
 
 <ul class="navbar-nav">
     @if (User.Identity?.IsAuthenticated == true)
     {
-        <span class="navbar-text text-body">Hello @User.Identity?.Name!</span>
+        var displayName = (User.Identity as ClaimsIdentity)?.FindFirst("name")?.Value ?? User.Identity?.Name;
+        <span class="navbar-text text-body">Hello @displayName!</span>
         <li class="nav-item">
             <a class="nav-link text-body" asp-area="MicrosoftIdentity" asp-controller="Account" asp-action="SignOut">Sign out</a>
         </li>


### PR DESCRIPTION
Added support for claims-based identity by including `System.Security.Claims`. Updated display name logic to first check for the "name" claim, falling back to
`User.Identity?.Name` if not available, improving user experience with potentially more friendly display names.