### PR TITLE
Enhance session cookie validation for authenticated users

### DIFF
--- a/src/Aspire/Aspire.AspNet.Mvc/Program.cs
+++ b/src/Aspire/Aspire.AspNet.Mvc/Program.cs
@@ -113,9 +113,14 @@ public class Program
 
         app.Use(async (context, next) =>
         {
+            // Only check for session cookie if the user is authenticated
             if (context.User.Identity?.IsAuthenticated == true)
             {
-                if (!context.Request.Cookies.ContainsKey("WebAppSession"))
+                // Only check for protected endpoints (not [AllowAnonymous])
+                var endpoint = context.GetEndpoint();
+                var allowAnonymous = endpoint?.Metadata.GetMetadata<IAllowAnonymous>() != null;
+
+                if (!allowAnonymous && !context.Request.Cookies.ContainsKey("WebAppSession"))
                 {
                     context.Response.Redirect("/MicrosoftIdentity/Account/SignOut");
                     return;


### PR DESCRIPTION
Added checks to ensure the "WebAppSession" cookie is verified only for authenticated users and protected endpoints. Users without the session cookie are redirected to the sign-out page, improving security for access to sensitive areas of the application.