### PR TITLE
Dev

### DIFF
--- a/.github/workflows/aspiredeploy.yml
+++ b/.github/workflows/aspiredeploy.yml
@@ -111,7 +111,23 @@ jobs:
               AzureAd__Domain=${{ secrets.AZUREAD_DOMAIN }} \
               AzureAd__TenantId=${{ secrets.AZUREAD_TENANT_ID }} \
               AzureAd__ClientId=${{ secrets.AZUREAD_APIAPP_ID }}
-      
+
+      # Ensure webfrontend ingress is configured for HTTP/2
+      - name: Ensure webfrontend ingress is HTTP/2
+        run: |
+          az containerapp ingress update \
+            --name ${{ env.ACA_WEBAPP_NAME }} \
+            --resource-group ${{ env.ACA_RESOURCE_GROUP }} \
+            --transport http2
+
+      # Ensure apiservice ingress is configured for HTTP/2
+      - name: Ensure apiservice ingress is HTTP/2
+        run: |
+          az containerapp ingress update \
+            --name ${{ env.ACA_APIAPP_NAME }} \
+            --resource-group ${{ env.ACA_RESOURCE_GROUP }} \
+            --transport http2
+
       # Get the FQDN (URL) of the deployed webfrontend app
       - name: Get webfrontend App URL
         id: get_app_url


### PR DESCRIPTION
This pull request updates the deployment workflow to ensure that ingress for both the web frontend and API service is configured to use HTTP/2. This change enhances the performance and compatibility of the deployed applications.

Deployment workflow updates:

* [`.github/workflows/aspiredeploy.yml`](diffhunk://#diff-5e4bdbe61eb767f0a9698e1821c4cb0b5206fcf25f3cc6c9cfbac406d0805aa8R115-R130): Added steps to configure HTTP/2 for the ingress of the `webfrontend` and `apiservice` applications using the Azure CLI.